### PR TITLE
Updated coffeelint to version 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "1.10.0",
     "chai": "1.9.1",
     "mocha": "2.3.3",
-    "coffeelint": "1.5.2"
+    "coffeelint": "1.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rocket:

coffeelint just published version 1.13.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 230 commits (ahead by 230, behind by 0).
- [6d6b9f4](https://github.com/clutchski/coffeelint/commit/6d6b9f471f257337539db2f4757627870d31a471): Releasing v1.13.0 for bugfixes
- [caf41c8](https://github.com/clutchski/coffeelint/commit/caf41c8890ac8e9bdf0297cf0bbd11eebca3c14c): Merge pull request #513 from swang/nlac_simple_class_bug
- [fb85011](https://github.com/clutchski/coffeelint/commit/fb85011c54d20062b3fde9084fb6723384bd5698): Merge pull request #507 from swang/remove_isInterpIndent
- [2adaad3](https://github.com/clutchski/coffeelint/commit/2adaad38368552aedcd6a4595a0f070a557f2640): Merge pull request #506 from swang/fix_chaining_indent
- [2e85e86](https://github.com/clutchski/coffeelint/commit/2e85e864e4ad0c9a801d51dc23717e23204d6f10): Merge pull request #512 from swang/rm_unnecessary_fat_arrow
- [03b8244](https://github.com/clutchski/coffeelint/commit/03b82446a3cc720b78b5df94d40e6daae6003ee5): newlines_after_classes: fix parsing for class ending
- [0c049a2](https://github.com/clutchski/coffeelint/commit/0c049a23cc525e1b2e93c10bd6c41d3fbab6251f): indent: Ignore indentations with explicit tag
- [f702de4](https://github.com/clutchski/coffeelint/commit/f702de40573ae2aa2b71b01818e9012ba34ebff8): missing_fat_arrows: remove unnecessary fat arrow
- [9a08e4c](https://github.com/clutchski/coffeelint/commit/9a08e4cb4f62bb37459b4ca5c392fd94f946bc82): indent: remove isInterpIndent check
- [6daba3c](https://github.com/clutchski/coffeelint/commit/6daba3c98b36913ebcddf2dc9778475497d23073): indent: fix chaining problems caused by regression
- [8cac447](https://github.com/clutchski/coffeelint/commit/8cac447926e64ab9aef3b993ada7a8f798fb3785): coffeelint: Added postpublish commands
- [de31256](https://github.com/clutchski/coffeelint/commit/de31256b12eeedce7d525541a52ed02bc1b6af79): Rerelease to handle npm not prepublishing
- [093bc9a](https://github.com/clutchski/coffeelint/commit/093bc9a8ceef7eecbdcdbb5dc8671bcec87f804e): New npm release
- [1720a76](https://github.com/clutchski/coffeelint/commit/1720a767b0128245c055f1ca4ea369a59ac5937c): Merge pull request #501 from camjc/patch-1
- [eeb78aa](https://github.com/clutchski/coffeelint/commit/eeb78aa0cf0d506567b4952315559070877d483e): Merge pull request #502 from swang/test_travis

There are 230 commits in total. See the [full diff](https://github.com/clutchski/coffeelint/compare/d789c1dd1a8e431cb96352c39b7628ee286f939e...6d6b9f471f257337539db2f4757627870d31a471).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
